### PR TITLE
feat: Implement seamless mobile background

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,8 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="theme-color" content="transparent" />
   <title>Kapitler — Spillelister</title>
   <!-- Typografi (print-inspirert) -->
@@ -27,73 +29,52 @@
     }
     * { box-sizing:border-box; }
     html {
-      background:var(--paper);
+      --grain-opacity: 0.04;
+      --vignette-strength: 0.1;
+
+      background-color: var(--paper);
+      background-image:
+        /* Vignette: a simple, single radial gradient for a soft edge darkening */
+        radial-gradient(ellipse at center, transparent 65%, rgba(0, 0, 0, var(--vignette-strength))),
+        /* Grain: using an SVG with baked-in opacity */
+        url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="220" height="220"><filter id="n"><feTurbulence type="fractalNoise" baseFrequency="0.85" numOctaves="2"/></filter><rect width="100%" height="100%" filter="url(%23n)" opacity="0.04"/></svg>');
+
+      background-attachment: fixed;
+      background-size: 100% 100%, auto;
     }
+
     body {
-      margin:0;
-      /* Viktig: reell bakgrunn = eksakt #729092 */
-      background:transparent;
-      color:var(--ink);
-      font-family:Inter, sans-serif;
-      line-height:1.65;
-      -webkit-font-smoothing:antialiased;
-      position:relative;
-      overflow-x:hidden;
-    }
+      margin: 0;
+      background-color: transparent;
+      color: var(--ink);
+      font-family: Inter, sans-serif;
+      line-height: 1.65;
+      -webkit-font-smoothing: antialiased;
+      position: relative;
+      overflow-x: hidden;
 
-    /* Papirtekstur/vignett legges under tint og innhold, så den ikke lysner fargen */
-    body::before {
-      content:"";
-      position:fixed; inset:0; pointer-events:none; z-index:0; /* under glød og tint */
-      background-image:url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="220" height="220"><filter id="n"><feTurbulence type="fractalNoise" baseFrequency="0.85" numOctaves="2"/></filter><rect width="100%" height="100%" filter="url(%23n)" opacity="0.22"/></svg>');
-      mix-blend-mode:multiply; opacity:.14; /* litt lavere så den ikke skifter lyshet */
-      animation: grainShift 24s steps(2,end) infinite;
-    }
-    body::after{
-      content:""; position:fixed; inset:-10% -10%; pointer-events:none; z-index:0; /* under glød og tint */
-      background:
-        radial-gradient(40% 35% at 20% 25%, rgba(0,0,0,.06), rgba(0,0,0,0) 60%),
-        radial-gradient(45% 40% at 80% 70%, rgba(0,0,0,.05), rgba(0,0,0,0) 60%),
-        radial-gradient(55% 50% at 50% 10%, rgba(0,0,0,.04), rgba(0,0,0,0) 65%);
-      opacity:.28; mix-blend-mode:multiply;
-      animation: vignetteDrift 80s linear infinite;
-    }
-    @keyframes grainShift { 0%,100%{transform:translate3d(0,0,0)} 50%{transform:translate3d(1px,-1px,0)} }
-    @keyframes vignetteDrift { 0%{transform:translate3d(0,0,0)} 50%{transform:translate3d(1.5%,-1.5%,0)} 100%{transform:translate3d(0,0,0)} }
-
-    /* Ny, lettvekts glød */
-    .glow-wrap { position: fixed; inset: 0; z-index: 1; pointer-events: none; }
-    .glow-layer {
-      position: absolute; 
-      inset: -20% -20%;
-      background: linear-gradient(135deg, 
-        var(--acc-blue), 
-        var(--acc-red), 
-        var(--acc-gold), 
-        var(--acc-plum), 
-        var(--acc-sky), 
-        var(--acc-blue));
+      /* Animated glow layer, blended softly over the html background */
+      background-image: linear-gradient(135deg,
+        var(--acc-blue), var(--acc-red), var(--acc-gold),
+        var(--acc-plum), var(--acc-sky), var(--acc-blue));
       background-size: 400% 400%;
-      opacity: 0.9;
-      will-change: background-position;
+      background-attachment: fixed;
+      background-blend-mode: soft-light;
+      background-position: 50% 50%;
       animation: stripeFlow 80s linear infinite;
     }
 
     /* Mobil og redusert bevegelse */
     @media (max-width: 768px), (hover: none), (pointer: coarse) {
-      .glow-layer { animation: none; opacity: 0.6; }
-      body::before,
-      body::after {
+      body {
         animation: none;
       }
     }
 
     @media (prefers-reduced-motion: reduce) {
-      .glow-layer,
+      body,
       .plate,
-      .stripe,
-      body::before,
-      body::after {
+      .stripe {
         animation: none;
       }
     }
@@ -116,7 +97,11 @@
     .brev h1 { font-family:"Archivo Black"; font-size:clamp(2rem,3.2vw,2.6rem); margin:0 0 12px; }
     .brev p { font-family:"Newsreader", serif; font-style:italic; color:var(--muted-text); max-width:70ch; margin:0 auto; }
 
-    main { padding:16px 20px 72px; position:relative; z-index:2; }
+    main {
+      padding: 16px calc(20px + env(safe-area-inset-right, 0)) calc(72px + env(safe-area-inset-bottom, 0)) calc(20px + env(safe-area-inset-left, 0));
+      position: relative;
+      z-index: 2;
+    }
     .grid { display:grid; gap:var(--gap); grid-template-columns:repeat(auto-fit, minmax(280px, 1fr)); max-width:var(--maxw); margin:0 auto; }
 
     /* Juster gap for mindre skjermer */
@@ -150,7 +135,13 @@
 
     .cover { width:100%; aspect-ratio:1/1; object-fit:cover; display:block; }
 
-    footer { text-align:center; font-size:1rem; padding:0 20px 64px; position:relative; z-index:2; }
+    footer {
+      text-align: center;
+      font-size: 1rem;
+      padding: 0 calc(20px + env(safe-area-inset-right, 0)) calc(64px + env(safe-area-inset-bottom, 0)) calc(20px + env(safe-area-inset-left, 0));
+      position: relative;
+      z-index: 2;
+    }
     .footer-note { font-family:"Inter", sans-serif; font-size:0.95rem; color:var(--muted); margin-bottom:12px; }
     .quote { max-width:800px; margin:0 auto; font-family:"Newsreader", serif; font-style:italic; font-size:1.1rem; line-height:1.9; color:var(--muted); text-align:center; }
     .quote strong { font-family:"Archivo Black", sans-serif; font-style:normal; font-size:1.15rem; margin:0 4px; color:var(--ink); }
@@ -169,11 +160,6 @@
   </style>
 </head>
 <body>
-  <!-- Ny, lettvekts glød -->
-  <div class="glow-wrap" aria-hidden="true">
-    <div class="glow-layer"></div>
-  </div>
-
   <header class="brev container" aria-label="Brev fra Marcus til Athina">
     <h1>Kjære Athina</h1>
     <p>Jeg har laget dette lille stedet for oss, et sted hvor musikken kan samle seg, kapittel for kapittel. Når du åpner listene, håper jeg du kjenner at tankene mine er hos deg.</p>


### PR DESCRIPTION
Refactors the page background implementation to create a seamless experience on mobile devices, where the background extends behind the system UI bars.

The key changes are:
- Replaced the `body::before`/`::after` pseudo-elements that used `mix-blend-mode` with a multi-layer CSS background on the `html` and `body` elements.
- The `html` element now has a static background composed of the base color, a vignette, and a grain texture. This ensures the top and bottom edges of the viewport are visually calm.
- The `body` element has an animated gradient with a `soft-light` blend mode to provide a dynamic color glow without affecting the root background sampling.
- Added `<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">` to allow the background to render under the status bar in iOS PWAs.
- Added `env(safe-area-inset-*)` padding to the `main` and `footer` elements to prevent content from being obscured by notches or home indicators.
- All animations respect `prefers-reduced-motion` and are disabled on mobile devices to improve performance and user experience.
- The old `.glow-wrap` element and associated styles have been removed.