### PR TITLE
Add interactive gift reveal page for Slottsfjell surprise

### DIFF
--- a/gave.html
+++ b/gave.html
@@ -2,44 +2,83 @@
 <html lang="no">
 <head>
   <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>En gave til deg, Athina</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Raleway:wght@400;700&family=Montserrat:wght@400;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="style.css">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <meta name="theme-color" content="#729092" />
+  <title>Åpne gaven – En overraskelse</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Archivo+Black&family=Inter:wght@300;400;600&family=Newsreader:ital,wght@0,300;0,400;1,300&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <div class="perspective-container">
-    <div class="container" id="container">
-      <header>
-        <h1 class="main-title">En gave til deg, Athina</h1>
-      </header>
-      <main class="gift-scene" id="giftScene">
-        <div class="gift-box" id="giftBox" role="button" tabindex="0" aria-label="En spesiell gave venter på deg. Klikk for å åpne.">
-          <div class="gift-band"></div>
-          <p class="gift-message">En spesiell gave venter på deg</p>
-        </div>
+  <div class="confetti-host" aria-hidden="true"></div>
+  <div class="container">
+    <header class="intro" aria-label="Åpne gaven fra Marcus til Athina">
+      <p class="intro-eyebrow">Til Athina</p>
+      <h1>En gave til deg</h1>
+      <p class="intro-text">Jeg ville pakke inn overraskelsen litt ekstra. Trykk på konvolutten – når den åpnes, får du se hva jeg har gjemt til oss.</p>
+    </header>
 
-        <div class="gift-content-frame" id="giftContent">
-          <div class="frame-inner">
-            <p class="frame-top-text">Her er en liten gave til deg - en opplevelse vi kan glede oss til sammen. Klikk på gaven for å dyppe den.</p>
-
-            <img src="assets/slottsfjell-logo.png" alt="Slottsfjell Logo" class="festival-logo">
-
-            <h2 class="festival-title">Slottsfjell 2026</h2>
-            <p class="festival-details">9.-10. Juli 2026</p>
-            <p class="festival-details">Slottsfjellet i Tønsberg</p>
-
-            <p class="frame-bottom-text">Kjære Athina, tenk at vi skal oppleve dette sammen! Gleder meg til å skape nye minner med deg.</p>
-
-            <a href="https://slottsfjell.no" class="festival-button" target="_blank" rel="noopener" aria-label="Utforsk nettsiden til Slottsfjell festivalen">Utforsk Festivalen</a>
+    <main>
+      <section class="gift-section" aria-labelledby="giftMessage">
+        <div
+          class="plate gift-box"
+          id="giftBox"
+          role="button"
+          tabindex="0"
+          aria-controls="giftReveal"
+          aria-expanded="false"
+          aria-pressed="false"
+          aria-describedby="giftMessage giftHint"
+        >
+          <div class="gift-envelope" aria-hidden="true">
+            <div class="envelope-body">
+              <span class="ticket-peek" aria-hidden="true">Til&nbsp;Athina</span>
+            </div>
+            <div class="envelope-flap"></div>
           </div>
+          <p class="gift-message" id="giftMessage">Trykk for å åpne gaven</p>
         </div>
-      </main>
-    </div>
+        <p class="gift-hint" id="giftHint">Tips: du kan bruke Enter eller Mellomrom hvis du navigerer med tastatur.</p>
+      </section>
+
+      <section class="reveal" id="giftReveal" aria-hidden="true" aria-live="polite">
+        <article class="plate festival-pass" role="group" aria-labelledby="festivalTitle">
+          <header class="pass-header">
+            <img src="assets/slottsfjell-logo.png" alt="Logoen til Slottsfjell-festivalen" class="festival-logo" />
+            <div class="pass-heading">
+              <p class="pass-label">Festivalpass</p>
+              <h2 id="festivalTitle" tabindex="-1">Slottsfjell 2026</h2>
+            </div>
+          </header>
+
+          <dl class="pass-meta">
+            <div>
+              <dt>Dato</dt>
+              <dd>9.–10. juli 2026</dd>
+            </div>
+            <div>
+              <dt>Sted</dt>
+              <dd>Slottsfjelltårnet, Tønsberg</dd>
+            </div>
+          </dl>
+
+          <p class="pass-intro">Gaven er billetter til Slottsfjell-festivalen 2026. Vi skal danse mellom tårnet og fjorden, midt i sommernatten.</p>
+          <p class="pass-note">Ta vare på dette digitale passet til vi står på sletten sammen. Jeg gleder meg til å oppleve alt dette med deg.</p>
+
+          <div class="pass-actions">
+            <a class="plate action-button primary" href="https://slottsfjell.no" target="_blank" rel="noopener" aria-label="Åpne nettsiden til Slottsfjell i en ny fane">
+              Utforsk slottsfjell.no
+            </a>
+            <button type="button" class="plate action-button secondary" aria-disabled="true">
+              Last ned billetten (kommer snart)
+            </button>
+          </div>
+        </article>
+      </section>
+    </main>
   </div>
-  <!-- Particles will be generated by JS to keep the HTML clean -->
+
   <script src="script.js" defer></script>
 </body>
 </html>

--- a/playlist.json
+++ b/playlist.json
@@ -25,8 +25,8 @@
     "url": "https://open.spotify.com/playlist/2HJmQo8RcBrNPhfd19GPjr?si=c5628689311849d5" 
   },
   {
-    "title": "En overraskelse...",
-    "subtitle": "Klikk for å åpne",
+    "title": "Åpne gaven",
+    "subtitle": "Jeg har gjemt noe spesielt her til deg.",
     "cover": "media/collage.png",
     "url": "gave.html"
   }

--- a/script.js
+++ b/script.js
@@ -6,18 +6,160 @@ document.addEventListener('DOMContentLoaded', () => {
   const focusTarget = document.getElementById('festivalTitle');
   const giftMessage = document.getElementById('giftMessage');
   const giftHint = document.getElementById('giftHint');
-  const motionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
 
+  const motionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
   let prefersReducedMotion = motionQuery.matches;
 
+  const PARTICLE_COUNT = 32;
+  const BACKGROUND_ELEMENT_COUNT = 9;
+  const particles = [];
+  const backgroundElements = [];
+
+  const encodeSvg = (svg) =>
+    encodeURIComponent(svg)
+      .replace(/'/g, '%27')
+      .replace(/"/g, '%22');
+
+  const particleColors = [
+    'var(--acc-gold)',
+    'var(--acc-plum)',
+    'var(--acc-blue)',
+    'rgba(255, 255, 255, 0.6)',
+  ];
+
+  const particleShapes = [
+    'circle(50%)',
+    'polygon(50% 0%, 0% 100%, 100% 100%)',
+    'polygon(16% 6%, 100% 18%, 84% 100%, 0 82%)',
+  ];
+
+  const backgroundSvgs = [
+    `url('data:image/svg+xml;utf8,${encodeSvg('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160"><path d="M80 6c26 18 42 44 42 74s-16 56-42 74c-26-18-42-44-42-74S54 24 80 6Z" fill="rgba(255,255,255,0.08)"/></svg>')}')`,
+    `url('data:image/svg+xml;utf8,${encodeSvg('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160"><path d="M22 118c34-14 54-46 58-90 16 34 42 60 76 70-30 10-54 32-66 60-12-24-34-38-68-40Z" fill="rgba(174,198,207,0.12)"/></svg>')}')`,
+    `url('data:image/svg+xml;utf8,${encodeSvg('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160"><path d="M80 18 95 63h48l-39 28 15 45-39-27-39 27 15-45-39-28h48Z" fill="rgba(201,166,107,0.12)"/></svg>')}')`,
+  ];
+
+  const randomFrom = (array) => array[Math.floor(Math.random() * array.length)];
+
+  const configureParticleMotion = (particle) => {
+    const xStart = Math.random() * window.innerWidth;
+    const yStart = Math.random() * window.innerHeight;
+    const xEnd = xStart + (Math.random() * 220 - 110);
+    const yEnd = yStart + (Math.random() * 220 - 110);
+    const duration = 18 + Math.random() * 16;
+    const delay = Math.random() * 12;
+    const opacity = 0.18 + Math.random() * 0.28;
+    const rotation = Math.random() * 360;
+
+    particle.style.setProperty('--x-start', `${xStart}px`);
+    particle.style.setProperty('--y-start', `${yStart}px`);
+    particle.style.setProperty('--x-end', `${xEnd}px`);
+    particle.style.setProperty('--y-end', `${yEnd}px`);
+    particle.style.setProperty('--duration', `${duration}s`);
+    particle.style.setProperty('--delay', `${delay}s`);
+    particle.style.setProperty('--opacity-max', opacity.toFixed(3));
+    particle.style.setProperty('--rotation', `${rotation}deg`);
+  };
+
+  const createParticles = () => {
+    if (prefersReducedMotion) return;
+    for (let i = 0; i < PARTICLE_COUNT; i += 1) {
+      const particle = document.createElement('span');
+      particle.className = 'particle';
+      const size = Math.random() * 14 + 8;
+      particle.style.setProperty('--size', `${size}px`);
+      particle.style.setProperty('--color', randomFrom(particleColors));
+      particle.style.setProperty('--shape', randomFrom(particleShapes));
+      configureParticleMotion(particle);
+      body.append(particle);
+      particles.push(particle);
+    }
+  };
+
+  const createBackgroundElements = () => {
+    if (prefersReducedMotion) return;
+    for (let i = 0; i < BACKGROUND_ELEMENT_COUNT; i += 1) {
+      const element = document.createElement('span');
+      element.className = 'bg-element';
+      const size = Math.random() * 120 + 80;
+      const top = Math.random() * window.innerHeight - size * 0.5;
+      const left = Math.random() * window.innerWidth - size * 0.5;
+      const duration = 26 + Math.random() * 18;
+      const delay = Math.random() * 14;
+      const driftX = (Math.random() - 0.5) * 160;
+      const driftY = (Math.random() - 0.5) * 160;
+      const rotationStart = Math.random() * 40 - 20;
+      const rotationEnd = rotationStart + (Math.random() * 40 - 20);
+      const opacity = 0.04 + Math.random() * 0.08;
+
+      element.style.setProperty('--size', `${size}px`);
+      element.style.setProperty('--svg', randomFrom(backgroundSvgs));
+      element.style.setProperty('--top', `${top}px`);
+      element.style.setProperty('--left', `${left}px`);
+      element.style.setProperty('--duration', `${duration}s`);
+      element.style.setProperty('--delay', `${delay}s`);
+      element.style.setProperty('--drift-x', `${driftX}px`);
+      element.style.setProperty('--drift-y', `${driftY}px`);
+      element.style.setProperty('--r-start', `${rotationStart}deg`);
+      element.style.setProperty('--r-end', `${rotationEnd}deg`);
+      element.style.setProperty('--opacity-max', opacity.toFixed(3));
+
+      body.append(element);
+      backgroundElements.push(element);
+    }
+  };
+
+  const clearMotionDecorations = () => {
+    particles.splice(0).forEach((node) => node.remove());
+    backgroundElements.splice(0).forEach((node) => node.remove());
+  };
+
+  const burstParticles = () => {
+    if (!particles.length || !giftBox) return;
+    const rect = giftBox.getBoundingClientRect();
+    const centerX = rect.left + rect.width / 2;
+    const centerY = rect.top + rect.height / 2;
+
+    particles.forEach((particle) => {
+      const angle = Math.random() * 360;
+      const distance = Math.random() * (window.innerWidth * 0.25) + 80;
+      const offsetX = Math.cos((angle * Math.PI) / 180) * distance;
+      const offsetY = Math.sin((angle * Math.PI) / 180) * distance;
+
+      particle.style.setProperty('--burst-origin-x', `${centerX}px`);
+      particle.style.setProperty('--burst-origin-y', `${centerY}px`);
+      particle.style.setProperty('--burst-offset-x', `${offsetX}px`);
+      particle.style.setProperty('--burst-offset-y', `${offsetY}px`);
+      particle.classList.add('burst');
+      particle.addEventListener(
+        'animationend',
+        () => {
+          particle.classList.remove('burst');
+          configureParticleMotion(particle);
+        },
+        { once: true },
+      );
+    });
+  };
+
+  const handleMotionPreferenceChange = (event) => {
+    prefersReducedMotion = event.matches;
+    clearMotionDecorations();
+    if (!prefersReducedMotion) {
+      createParticles();
+      createBackgroundElements();
+    }
+  };
+
   if (typeof motionQuery.addEventListener === 'function') {
-    motionQuery.addEventListener('change', (event) => {
-      prefersReducedMotion = event.matches;
-    });
+    motionQuery.addEventListener('change', handleMotionPreferenceChange);
   } else if (typeof motionQuery.addListener === 'function') {
-    motionQuery.addListener((event) => {
-      prefersReducedMotion = event.matches;
-    });
+    motionQuery.addListener(handleMotionPreferenceChange);
+  }
+
+  if (!prefersReducedMotion) {
+    createParticles();
+    createBackgroundElements();
   }
 
   const launchConfetti = () => {
@@ -93,6 +235,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     if (!prefersReducedMotion) {
       launchConfetti();
+      burstParticles();
       window.setTimeout(focusFestivalTitle, 450);
     } else {
       focusFestivalTitle();

--- a/script.js
+++ b/script.js
@@ -1,135 +1,113 @@
 document.addEventListener('DOMContentLoaded', () => {
-  const PARTICLE_COUNT = 30;
-  const BG_ELEMENT_COUNT = 10;
   const body = document.body;
+  const giftBox = document.getElementById('giftBox');
+  const giftReveal = document.getElementById('giftReveal');
+  const confettiHost = document.querySelector('.confetti-host');
+  const focusTarget = document.getElementById('festivalTitle');
+  const giftMessage = document.getElementById('giftMessage');
+  const giftHint = document.getElementById('giftHint');
+  const motionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
 
-  const elements = {
-    giftBox: document.getElementById('giftBox'),
-    body: document.body
-  };
+  let prefersReducedMotion = motionQuery.matches;
 
-  const particleColors = [
-    'var(--matte-gold)',
-    'var(--rust-red)',
-    'var(--light-beige)',
-    'var(--dusty-blue)',
-  ];
-
-  const particleShapes = {
-    circle: 'circle(50%)',
-    triangle: 'polygon(50% 0%, 0% 100%, 100% 100%)',
-  };
-
-  const bgElementSVGs = {
-    leaf: `url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 50 100"><path d="M25 0 C-10 20, -10 80, 25 100 C60 80, 60 20, 25 0Z" fill="rgba(255,255,255,0.06)"/></svg>')`,
-    note: `url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 80"><circle cx="20" cy="70" r="10" fill="rgba(255,255,255,0.06)"/><rect x="28" y="10" width="5" height="65" fill="rgba(255,255,255,0.06)"/></svg>')`,
-    flower: `url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><path d="M50 0 L61.8 38.2 L100 38.2 L69.1 61.8 L80.9 100 L50 76.4 L19.1 100 L30.9 61.8 L0 38.2 L38.2 38.2 Z" fill="rgba(255,255,255,0.05)"/></svg>')`
-  };
-
-  function createParticles() {
-    for (let i = 0; i < PARTICLE_COUNT; i++) {
-      const particle = document.createElement('div');
-      // ... (rest of the function is the same as before)
-      particle.className = 'particle';
-
-      const size = Math.random() * 15 + 5;
-      const color = particleColors[Math.floor(Math.random() * particleColors.length)];
-      const shapeKeys = Object.keys(particleShapes);
-      const shape = particleShapes[shapeKeys[Math.floor(Math.random() * shapeKeys.length)]];
-
-      const xStart = Math.random() * window.innerWidth;
-      const yStart = Math.random() * window.innerHeight;
-      const xEnd = Math.random() * window.innerWidth;
-      const yEnd = Math.random() * window.innerHeight;
-
-      const duration = Math.random() * 20 + 15;
-      const delay = Math.random() * 10;
-      const maxOpacity = Math.random() * 0.4 + 0.1;
-
-      particle.style.setProperty('--size', `${size}px`);
-      particle.style.setProperty('--color', color);
-      particle.style.setProperty('--radius', shape === 'circle(50%)' ? '50%' : '0');
-      particle.style.setProperty('--shape', shape);
-      particle.style.setProperty('--x-start', `${xStart}px`);
-      particle.style.setProperty('--y-start', `${yStart}px`);
-      particle.style.setProperty('--x-end', `${xEnd}px`);
-      particle.style.setProperty('--y-end', `${yEnd}px`);
-      particle.style.setProperty('--duration', `${duration}s`);
-      particle.style.setProperty('--delay', `${delay}s`);
-      particle.style.setProperty('--opacity-max', maxOpacity);
-
-      body.appendChild(particle);
-    }
-  }
-
-  function createBackgroundElements() {
-    const svgs = Object.values(bgElementSVGs);
-    for (let i = 0; i < BG_ELEMENT_COUNT; i++) {
-      const el = document.createElement('div');
-      el.className = 'bg-element';
-
-      const size = Math.random() * 80 + 40;
-      const svg = svgs[Math.floor(Math.random() * svgs.length)];
-
-      const edge = Math.floor(Math.random() * 4);
-      let x, y;
-      const margin = size; // Ensure it starts off-screen
-      if (edge === 0) { y = -margin; x = Math.random() * window.innerWidth; }
-      else if (edge === 1) { x = window.innerWidth; y = Math.random() * window.innerHeight; }
-      else if (edge === 2) { y = window.innerHeight; x = Math.random() * window.innerWidth; }
-      else { x = -margin; y = Math.random() * window.innerHeight; }
-
-      el.style.setProperty('--size', `${size}px`);
-      el.style.setProperty('--svg', svg);
-      el.style.top = `${y}px`;
-      el.style.left = `${x}px`;
-      el.style.setProperty('--duration', `${Math.random() * 20 + 15}s`);
-      el.style.setProperty('--delay', `${Math.random() * 15}s`);
-      el.style.setProperty('--r-start', `${Math.random() * 40 - 20}deg`);
-      el.style.setProperty('--r-end', `${Math.random() * 40 - 20}deg`);
-
-      body.appendChild(el);
-    }
-  }
-
-  function openGift() {
-    // ... (same as before)
-    if (elements.body.classList.contains('is-opened')) return;
-
-    elements.body.classList.add('is-opened');
-
-    const particles = document.querySelectorAll('.particle');
-    const giftBoxRect = elements.giftBox.getBoundingClientRect();
-    const giftBoxCenterX = giftBoxRect.left + giftBoxRect.width / 2;
-    const giftBoxCenterY = giftBoxRect.top + giftBoxRect.height / 2;
-
-    particles.forEach(particle => {
-      const angle = Math.random() * 360;
-      const distance = (Math.random() * 0.5 + 0.5) * (window.innerWidth / 4);
-      const xVector = Math.cos(angle * Math.PI / 180) * distance;
-      const yVector = Math.sin(angle * Math.PI / 180) * distance;
-
-      particle.style.setProperty('--x-start-burst', `${giftBoxCenterX}px`);
-      particle.style.setProperty('--y-start-burst', `${giftBoxCenterY}px`);
-      particle.style.setProperty('--x-vector-burst', `${xVector}px`);
-      particle.style.setProperty('--y-vector-burst', `${yVector}px`);
-
-      particle.style.animation = 'none';
-      void particle.offsetWidth;
-      particle.style.animation = `particle-burst 1.2s ease-out forwards`;
+  if (typeof motionQuery.addEventListener === 'function') {
+    motionQuery.addEventListener('change', (event) => {
+      prefersReducedMotion = event.matches;
+    });
+  } else if (typeof motionQuery.addListener === 'function') {
+    motionQuery.addListener((event) => {
+      prefersReducedMotion = event.matches;
     });
   }
 
-  if (elements.giftBox) {
-    elements.giftBox.addEventListener('click', openGift, { once: true });
-    elements.giftBox.addEventListener('keydown', (event) => {
-        if (event.key === 'Enter' || event.key === ' ') {
-          event.preventDefault();
-          openGift();
-        }
-      }, { once: true });
-  }
+  const launchConfetti = () => {
+    if (!confettiHost) return;
 
-  createParticles();
-  createBackgroundElements();
+    confettiHost.innerHTML = '';
+    const colors = ['var(--acc-blue)', 'var(--acc-red)', 'var(--acc-gold)', 'var(--acc-plum)', 'var(--acc-sky)'];
+    const shapes = ['0', '50%'];
+    const pieceCount = 70;
+
+    for (let i = 0; i < pieceCount; i += 1) {
+      const piece = document.createElement('span');
+      piece.className = 'confetti-piece';
+
+      const size = Math.random() * 8 + 6;
+      const color = colors[i % colors.length];
+      const left = Math.random() * 100;
+      const delay = Math.random() * 0.6;
+      const duration = 2.2 + Math.random() * 1.6;
+      const drift = Math.random() * 90 - 45;
+      const rotation = Math.random() * 600 + 360;
+      const radiusShape = shapes[Math.floor(Math.random() * shapes.length)];
+
+      piece.style.setProperty('--size', `${size}px`);
+      piece.style.setProperty('--color', color);
+      piece.style.setProperty('--delay', `${delay}s`);
+      piece.style.setProperty('--duration', `${duration}s`);
+      piece.style.setProperty('--drift', `${drift}px`);
+      piece.style.setProperty('--rotation', `${rotation}deg`);
+      piece.style.setProperty('--radius-shape', radiusShape);
+      piece.style.left = `${left}%`;
+
+      confettiHost.append(piece);
+      piece.addEventListener('animationend', () => {
+        piece.remove();
+      });
+    }
+
+    window.setTimeout(() => {
+      confettiHost.innerHTML = '';
+    }, 4200);
+  };
+
+  const openGift = () => {
+    if (!giftBox || body.classList.contains('gift-open')) {
+      return;
+    }
+
+    body.classList.add('gift-open');
+    giftBox.setAttribute('aria-pressed', 'true');
+    giftBox.setAttribute('aria-expanded', 'true');
+    giftBox.setAttribute('aria-disabled', 'true');
+    giftBox.setAttribute('tabindex', '-1');
+    giftBox.setAttribute('aria-label', 'Gaven er åpnet');
+    giftBox.removeAttribute('aria-describedby');
+    giftBox.removeEventListener('click', openGift);
+    giftBox.removeEventListener('keydown', handleKeydown);
+    if (giftMessage) {
+      giftMessage.setAttribute('aria-hidden', 'true');
+    }
+    if (giftHint) {
+      giftHint.setAttribute('hidden', '');
+    }
+    if (giftReveal) {
+      giftReveal.setAttribute('aria-hidden', 'false');
+    }
+
+    const focusFestivalTitle = () => {
+      if (focusTarget) {
+        focusTarget.focus({ preventScroll: false });
+      }
+    };
+
+    if (!prefersReducedMotion) {
+      launchConfetti();
+      window.setTimeout(focusFestivalTitle, 450);
+    } else {
+      focusFestivalTitle();
+    }
+  };
+
+  const handleKeydown = (event) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      openGift();
+    }
+  };
+
+  if (giftBox) {
+    giftBox.addEventListener('click', openGift);
+    giftBox.addEventListener('keydown', handleKeydown);
+  }
 });

--- a/style.css
+++ b/style.css
@@ -54,6 +54,47 @@ body {
   animation: stripeFlow 120s linear infinite;
 }
 
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="220" height="220"><filter id="n"><feTurbulence type="fractalNoise" baseFrequency="0.75" numOctaves="2"/></filter><rect width="100%" height="100%" filter="url(%23n)" opacity="0.55"/></svg>');
+  opacity: 0.06;
+  animation: paperDrift 18s ease-in-out infinite;
+}
+
+body::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+  background-image:
+    radial-gradient(circle at 22% 18%, rgba(255, 255, 255, 0.22), transparent 58%),
+    radial-gradient(circle at 82% 22%, rgba(255, 255, 255, 0.16), transparent 62%),
+    linear-gradient(135deg, rgba(0, 115, 198, 0.08), rgba(201, 166, 107, 0.08), rgba(91, 74, 88, 0.08));
+  opacity: 0;
+  transition: opacity 1600ms ease;
+}
+
+body.gift-open::after {
+  opacity: 0.35;
+}
+
+@keyframes paperDrift {
+  0%,
+  100% {
+    opacity: 0.05;
+    transform: translate3d(0, 0, 0);
+  }
+  50% {
+    opacity: 0.08;
+    transform: translate3d(0, -12px, 0);
+  }
+}
+
 @keyframes stripeFlow {
   0% {
     background-position: 0% 50%;
@@ -83,13 +124,25 @@ body {
   .gift-envelope,
   .envelope-flap,
   .festival-pass,
-  .confetti-piece {
+  .confetti-piece,
+  .particle,
+  .bg-element {
     animation: none !important;
     transition-duration: 0ms !important;
   }
 
   .confetti-host {
     display: none;
+  }
+
+  .particle,
+  .bg-element {
+    display: none;
+  }
+
+  body::before,
+  body::after {
+    animation: none;
   }
 
   body.gift-open .gift-box {
@@ -422,6 +475,86 @@ body.gift-open .festival-pass {
 .plate.action-button[aria-disabled="true"] {
   cursor: not-allowed;
   opacity: 0.7;
+}
+
+.particle {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: var(--size, 12px);
+  height: var(--size, 12px);
+  background: var(--color, rgba(255, 255, 255, 0.45));
+  clip-path: var(--shape, circle(50%));
+  opacity: 0;
+  pointer-events: none;
+  z-index: 1;
+  filter: drop-shadow(0 4px 10px rgba(0, 0, 0, 0.18));
+  transform: translate3d(var(--x-start, 0px), var(--y-start, 0px), 0) rotate(0deg);
+  animation: float var(--duration, 24s) ease-in-out var(--delay, 0s) infinite;
+  mix-blend-mode: screen;
+}
+
+.particle.burst {
+  animation: particleBurst 1.2s ease-out forwards;
+}
+
+@keyframes float {
+  0% {
+    opacity: 0;
+    transform: translate3d(var(--x-start, 0px), var(--y-start, 0px), 0) rotate(0deg);
+  }
+  15%,
+  85% {
+    opacity: var(--opacity-max, 0.35);
+  }
+  100% {
+    opacity: 0;
+    transform: translate3d(var(--x-end, 0px), var(--y-end, 0px), 0) rotate(var(--rotation, 360deg));
+  }
+}
+
+@keyframes particleBurst {
+  0% {
+    opacity: var(--opacity-max, 0.35);
+    transform: translate3d(var(--burst-origin-x, 0px), var(--burst-origin-y, 0px), 0) scale(1);
+  }
+  100% {
+    opacity: 0;
+    transform: translate3d(
+        calc(var(--burst-origin-x, 0px) + var(--burst-offset-x, 0px)),
+        calc(var(--burst-origin-y, 0px) + var(--burst-offset-y, 0px)),
+        0
+      )
+      scale(0.4);
+  }
+}
+
+.bg-element {
+  position: fixed;
+  top: var(--top, 0px);
+  left: var(--left, 0px);
+  width: var(--size, 120px);
+  height: var(--size, 120px);
+  background-image: var(--svg);
+  background-size: contain;
+  background-repeat: no-repeat;
+  opacity: 0;
+  pointer-events: none;
+  z-index: 1;
+  transform: translate3d(0, 0, 0) rotate(var(--r-start, 0deg));
+  animation: backgroundGlide var(--duration, 30s) ease-in-out var(--delay, 0s) infinite;
+}
+
+@keyframes backgroundGlide {
+  0%,
+  100% {
+    opacity: 0;
+    transform: translate3d(0, 0, 0) rotate(var(--r-start, 0deg));
+  }
+  50% {
+    opacity: var(--opacity-max, 0.1);
+    transform: translate3d(var(--drift-x, 0px), var(--drift-y, 0px), 0) rotate(var(--r-end, 0deg));
+  }
 }
 
 .confetti-host {

--- a/style.css
+++ b/style.css
@@ -1,346 +1,497 @@
-/* --- General Setup & Colors --- */
 :root {
-  --golden-brown: #a98a67;
-  --grey-blue: #6d7b8d;
-  --deep-purple-brown: #5b4a58;
-  --matte-gold: #c5a56b;
-  --dark-text: #3d3a36;
-  --light-beige: #f5f1e8;
-  --rust-red: #b45f49;
-  --dusty-blue: #8b9ea7;
-  --paper-texture-opacity: 0.05;
+  --paper: #729092;
+  --ink: #111;
+  --muted: #3D3A36;
+  --muted-text: #2A2825;
+  --maxw: 1120px;
+  --radius: 12px;
+  --shadow: 0 14px 32px rgba(0, 0, 0, 0.14);
+  --shadow-hover: 0 20px 40px rgba(0, 0, 0, 0.18);
+  --gap: 26px;
+  --acc-blue: #0073C6;
+  --acc-red: #D93C3C;
+  --acc-gold: #C9A66B;
+  --acc-plum: #5B4A58;
+  --acc-sky: #AEC6CF;
 }
 
 * {
   box-sizing: border-box;
-  margin: 0;
-  padding: 0;
+}
+
+html {
+  background-color: var(--paper);
+  background-image:
+    radial-gradient(ellipse at center, transparent 65%, rgba(0, 0, 0, 0.1)),
+    url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="220" height="220"><filter id="n"><feTurbulence type="fractalNoise" baseFrequency="0.85" numOctaves="2"/></filter><rect width="100%" height="100%" filter="url(%23n)" opacity="0.04"/></svg>');
+  background-attachment: fixed;
+  background-size: 100% 100%, auto;
 }
 
 body {
-  font-family: 'Raleway', sans-serif;
-  color: var(--dark-text);
-  background-color: var(--grey-blue); /* Fallback */
-  background-image: linear-gradient(to bottom, var(--golden-brown), var(--grey-blue));
+  margin: 0;
   min-height: 100vh;
-  overflow: hidden; /* Prevents scrollbars from appearing due to particles */
+  color: var(--ink);
+  font-family: "Inter", sans-serif;
+  line-height: 1.65;
+  -webkit-font-smoothing: antialiased;
   position: relative;
+  overflow-x: hidden;
+  background-color: transparent;
+  background-image: linear-gradient(
+    135deg,
+    var(--acc-blue),
+    var(--acc-red),
+    var(--acc-gold),
+    var(--acc-plum),
+    var(--acc-sky),
+    var(--acc-blue)
+  );
+  background-size: 420% 420%;
+  background-attachment: fixed;
+  background-blend-mode: soft-light;
+  background-position: 50% 50%;
+  animation: stripeFlow 120s linear infinite;
 }
 
-/* --- Breathing Paper Texture --- */
-body::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200"><filter id="n"><feTurbulence type="fractalNoise" baseFrequency="0.7" numOctaves="2"/></filter><rect width="100%" height="100%" filter="url(%23n)" opacity="0.4"/></svg>');
-  opacity: var(--paper-texture-opacity);
-  animation: breathing 15s ease-in-out infinite;
-  z-index: 1; /* Above background, below content */
-  pointer-events: none;
+@keyframes stripeFlow {
+  0% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0% 50%;
+  }
 }
 
-@keyframes breathing {
-  0% { opacity: 0.04; }
-  50% { opacity: 0.06; }
-  100% { opacity: 0.04; }
+@media (max-width: 768px), (hover: none), (pointer: coarse) {
+  body {
+    animation: none;
+  }
 }
 
-/* --- Layout & Typography --- */
-.perspective-container {
-  perspective: 1000px;
+@media (prefers-reduced-motion: reduce) {
+  body {
+    animation: none;
+  }
+
+  .plate,
+  .gift-box,
+  .gift-box::before,
+  .gift-envelope,
+  .envelope-flap,
+  .festival-pass,
+  .confetti-piece {
+    animation: none !important;
+    transition-duration: 0ms !important;
+  }
+
+  .confetti-host {
+    display: none;
+  }
+
+  body.gift-open .gift-box {
+    transform: none;
+  }
 }
 
 .container {
+  max-width: var(--maxw);
+  margin: 0 auto;
+  padding: 56px 24px 64px;
   position: relative;
-  z-index: 2; /* Above texture */
+  z-index: 2;
+  padding-top: calc(56px + env(safe-area-inset-top, 0));
+  padding-right: calc(24px + env(safe-area-inset-right, 0));
+  padding-bottom: calc(64px + env(safe-area-inset-bottom, 0));
+  padding-left: calc(24px + env(safe-area-inset-left, 0));
+}
+
+.intro {
+  text-align: center;
+  max-width: 720px;
+  margin: 0 auto 48px;
+}
+
+.intro-eyebrow {
+  font-family: "Inter", sans-serif;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: 0.8rem;
+  color: rgba(17, 17, 17, 0.55);
+  margin-bottom: 12px;
+}
+
+.intro h1 {
+  font-family: "Archivo Black", sans-serif;
+  font-size: clamp(2.1rem, 4vw, 2.8rem);
+  margin: 0 0 12px;
+}
+
+.intro-text {
+  font-family: "Newsreader", serif;
+  font-style: italic;
+  color: var(--muted-text);
+  margin: 0 auto;
+  max-width: 60ch;
+}
+
+main {
   display: flex;
   flex-direction: column;
-  justify-content: flex-start;
   align-items: center;
-  min-height: 100vh;
-  padding: 2rem;
+  gap: clamp(3rem, 6vw, 4.5rem);
+}
+
+.gift-section {
   text-align: center;
 }
 
-.main-title {
-  font-family: 'Montserrat', sans-serif;
-  font-weight: 700;
-  font-size: clamp(1.5rem, 4vw, 2.5rem);
-  color: var(--dark-text);
-  margin-top: 2rem;
-  margin-bottom: 4rem;
+.plate {
+  display: block;
+  border-radius: var(--radius);
+  background: rgba(255, 255, 255, 0.58);
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  box-shadow: var(--shadow);
+  text-decoration: none;
+  color: inherit;
+  position: relative;
+  transform: translateZ(0);
+  transition: transform 0.5s ease, box-shadow 0.4s ease, opacity 0.4s ease;
+  will-change: transform;
+  backdrop-filter: blur(6px);
 }
 
-/* --- Gift Box --- */
-.gift-scene {
-  display: grid;
-  place-items: center;
+.plate:hover {
+  box-shadow: var(--shadow-hover);
+}
+
+.plate:focus-visible {
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.16);
+  outline: 2px solid var(--acc-blue);
+  outline-offset: 4px;
 }
 
 .gift-box {
-  position: relative;
-  width: 250px;
-  height: 350px;
-  background-color: var(--deep-purple-brown);
-  border: 1px solid rgba(0,0,0,0.1);
-  border-radius: 4px 2px 5px 3px; /* Subtle irregular paper edge */
+  width: clamp(260px, 48vw, 360px);
+  padding: 32px 28px 40px;
   cursor: pointer;
-  transition: transform 0.3s ease, box-shadow 0.3s ease;
-  box-shadow: 0 10px 25px rgba(0,0,0,0.2), 0 0 0 10px rgba(255,255,255,0.03) inset;
+  background: rgba(255, 255, 255, 0.62);
+  animation: wind 14s cubic-bezier(0.45, 0.05, 0.35, 0.95) infinite;
+  transform-origin: center;
+  overflow: visible;
 }
 
-.gift-box:hover {
-  transform: translateY(-10px) scale(1.02);
-  box-shadow: 0 20px 35px rgba(0,0,0,0.3), 0 0 0 10px rgba(255,255,255,0.03) inset;
+@keyframes wind {
+  0% {
+    transform: translateY(0) rotate(0deg);
+  }
+  25% {
+    transform: translateY(-6px) rotate(-0.25deg);
+  }
+  50% {
+    transform: translateY(3px) rotate(0.2deg);
+  }
+  75% {
+    transform: translateY(-4px) rotate(-0.15deg);
+  }
+  100% {
+    transform: translateY(0) rotate(0deg);
+  }
 }
 
-.gift-band {
-  position: absolute;
-  top: 0;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 70px;
-  height: 100%;
-  background-color: var(--matte-gold);
-  border-left: 1px solid rgba(0,0,0,0.1);
-  border-right: 1px solid rgba(0,0,0,0.1);
-}
-
-.gift-message {
+.gift-envelope {
   position: relative;
-  z-index: 1;
-  color: var(--deep-purple-brown);
-  font-family: 'Raleway', sans-serif;
-  font-style: italic;
-  font-size: 1.1rem;
-  top: 50%;
-  transform: translateY(-50%);
-  padding: 0 1rem;
-  pointer-events: none; /* So it doesn't interfere with the gift box click */
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  perspective: 1200px;
+  transform-style: preserve-3d;
 }
 
-/* --- Floating Particles --- */
-.particle {
+.envelope-body {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.95), rgba(255, 255, 255, 0.75));
+  border-radius: 14px;
+  box-shadow:
+    inset 0 0 0 1px rgba(17, 17, 17, 0.06),
+    0 12px 28px rgba(17, 17, 17, 0.15);
+}
+
+.envelope-body::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0) 35%, rgba(114, 144, 146, 0.16));
+}
+
+.ticket-peek {
+  position: absolute;
+  left: 50%;
+  top: 18%;
+  transform: translateX(-50%);
+  padding: 10px 20px;
+  border-radius: 10px;
+  background: linear-gradient(120deg, rgba(0, 115, 198, 0.15), rgba(201, 166, 107, 0.25));
+  color: var(--muted);
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  font-size: 0.85rem;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.12);
+}
+
+.envelope-flap {
   position: absolute;
   top: 0;
   left: 0;
-  pointer-events: none;
-  background: var(--color);
-  border-radius: var(--radius);
-  opacity: 0;
-  animation: float var(--duration) var(--delay) infinite ease-in-out;
-  will-change: transform, opacity;
-  width: var(--size);
-  height: var(--size);
-  clip-path: var(--shape);
-}
-
-@keyframes float {
-  0% {
-    transform: translateX(var(--x-start)) translateY(var(--y-start)) rotate(0deg);
-    opacity: 0;
-  }
-  15%, 85% {
-    opacity: var(--opacity-max);
-  }
-  100% {
-    transform: translateX(var(--x-end)) translateY(var(--y-end)) rotate(360deg);
-    opacity: 0;
-  }
-}
-
-/* --- Opening Animations --- */
-
-/* 1. Background Shift */
-body {
-  --opened-golden-brown: #c4a98a; /* Lighter */
-  --opened-grey-blue: #8392a4;   /* Lighter, more blue */
-  /* This transition won't work on gradients directly. We'll handle it differently. */
-  /* A pseudo-element fade is a good technique. */
-}
-
-body::after {
-  content: '';
-  position: absolute;
-  top: 0; left: 0; width: 100%; height: 100%;
-  background-image: linear-gradient(to bottom, var(--opened-golden-brown), var(--opened-grey-blue));
-  opacity: 0;
-  transition: opacity 2s ease-in-out;
-  z-index: 0; /* Below main content, above main background */
-  pointer-events: none;
-}
-
-body.is-opened::after {
-  opacity: 1;
-}
-
-/* 2. Gift Box Unfolding */
-@keyframes unfold-box {
-  0% {
-    transform: rotateX(0deg) scale(1);
-    opacity: 1;
-  }
-  100% {
-    transform: rotateX(70deg) scale(0.9) translateY(-200px) translateZ(-100px);
-    opacity: 0;
-  }
-}
-
-body.is-opened .gift-box {
-  animation: unfold-box 1.5s ease-in-out forwards;
-  animation-delay: 0.1s;
-  cursor: default;
-}
-
-/* 3. Ribbon Falling */
-@keyframes unravel-ribbon {
-  0% {
-    transform: translateY(0) scaleY(1);
-    opacity: 1;
-  }
-  100% {
-    transform: translateY(200px) scaleY(0.5);
-    opacity: 0;
-  }
-}
-
-body.is-opened .gift-band,
-body.is-opened .gift-message {
-  animation: unravel-ribbon 0.8s ease-in forwards;
-}
-
-
-/* 4. Particle Burst */
-@keyframes particle-burst {
-  0% {
-    transform: translate(var(--x-start-burst), var(--y-start-burst)) scale(1);
-    opacity: var(--opacity-max);
-  }
-  100% {
-    transform: translate(
-      calc(var(--x-start-burst) + var(--x-vector-burst)),
-      calc(var(--y-start-burst) + var(--y-vector-burst))
-    ) scale(0);
-    opacity: 0;
-  }
-}
-
-body.is-opened .particle {
-  /* Override the floating animation with the burst */
-  animation: particle-burst 1.2s ease-out forwards;
-  animation-delay: 0.1s; /* Stagger the burst slightly */
-}
-
-/* --- Revealed Content --- */
-.gift-content-frame {
-  position: absolute;
   width: 100%;
-  max-width: 550px;
-  background-color: var(--light-beige);
-  border-radius: 6px 4px 8px 5px;
-  padding: 2rem 2.5rem;
-  box-shadow: 0 15px 40px rgba(0,0,0,0.2);
-  border: 1px solid rgba(0,0,0,0.08);
-
-  /* Hide by default using display: none */
-  display: none;
-
-  /* Add noise texture */
-  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="150" height="150"><filter id="n"><feTurbulence type="fractalNoise" baseFrequency="0.8" numOctaves="1"/></filter><rect width="100%" height="100%" filter="url(%23n)" opacity="0.2"/></svg>');
+  height: 58%;
+  border-radius: 14px 14px 6px 6px;
+  background: linear-gradient(165deg, rgba(255, 255, 255, 0.96), rgba(174, 198, 207, 0.45));
+  clip-path: polygon(0 0, 50% 58%, 100% 0, 100% 100%, 0 100%);
+  box-shadow: inset 0 0 0 1px rgba(17, 17, 17, 0.05);
+  transform-origin: top;
+  transform: rotateX(0deg);
+  transition: transform 0.9s cubic-bezier(0.33, 0.05, 0.18, 0.99);
+  backface-visibility: hidden;
 }
 
-.frame-inner {
+.gift-message {
+  margin: 24px auto 0;
+  font-family: "Newsreader", serif;
+  font-style: italic;
+  color: var(--muted-text);
+  max-width: 24ch;
+  transition: opacity 0.4s ease;
+}
+
+.gift-message[aria-hidden="true"] {
+  display: none;
+}
+
+.gift-hint {
+  font-size: 0.95rem;
+  color: rgba(17, 17, 17, 0.65);
+  margin-top: 18px;
+  font-family: "Inter", sans-serif;
+}
+
+body.gift-open .gift-box {
+  animation-play-state: paused;
+  transform: translateY(-50px) scale(0.88) rotateX(16deg);
+  opacity: 0;
+  pointer-events: none;
+}
+
+body.gift-open .envelope-flap {
+  transform: rotateX(-170deg);
+}
+
+body.gift-open .gift-message {
+  opacity: 0;
+}
+
+.reveal {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+
+.festival-pass {
+  max-width: 640px;
+  padding: clamp(32px, 5vw, 48px);
   display: flex;
   flex-direction: column;
-  align-items: center;
-  gap: 1rem;
+  gap: 1.2rem;
+  opacity: 0;
+  transform: translateY(24px);
+  transition: transform 0.7s ease, opacity 0.7s ease;
+  pointer-events: none;
 }
 
-body.is-opened .gift-content-frame {
-  display: block; /* Show when opened */
+body.gift-open .festival-pass {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+.pass-header {
+  display: flex;
+  align-items: center;
+  gap: 1.2rem;
 }
 
 .festival-logo {
-  width: 100px;
+  width: clamp(68px, 12vw, 96px);
   height: auto;
-  margin: 0.5rem 0;
-  filter: sepia(0.2) saturate(0.8) contrast(0.9); /* Vintage feel */
+  filter: drop-shadow(0 6px 16px rgba(0, 0, 0, 0.18));
 }
 
-.festival-title {
-  font-family: 'Montserrat', sans-serif;
-  font-weight: 700;
-  font-size: clamp(2rem, 5vw, 3rem);
-  color: #2A2825; /* Restored dark color */
-  line-height: 1.1;
-  margin-top: 0.5rem;
+.pass-label {
+  font-family: "Inter", sans-serif;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 0.8rem;
+  margin: 0 0 4px;
+  color: rgba(17, 17, 17, 0.55);
 }
 
-.festival-details {
-  font-family: 'Raleway', sans-serif;
+.pass-heading h2 {
+  font-family: "Archivo Black", sans-serif;
+  font-size: clamp(2rem, 5vw, 2.6rem);
+  margin: 0;
+  color: var(--acc-blue);
+}
+
+.pass-meta {
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 18px;
+}
+
+.pass-meta div {
+  background: rgba(255, 255, 255, 0.65);
+  border: 1px solid rgba(0, 0, 0, 0.05);
+  border-radius: 12px;
+  padding: 16px 18px;
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.04);
+}
+
+.pass-meta dt {
+  margin: 0 0 6px;
+  font-family: "Archivo Black", sans-serif;
+  font-size: 0.9rem;
+  letter-spacing: 0.05em;
+  color: var(--muted);
+}
+
+.pass-meta dd {
+  margin: 0;
+  font-weight: 600;
   font-size: 1.1rem;
-  margin-top: -0.5rem;
-  color: var(--dark-text);
-  font-weight: 500;
 }
 
-.frame-top-text, .frame-bottom-text {
-  font-family: 'Raleway', sans-serif;
+.pass-intro,
+.pass-note {
+  margin: 0;
+  font-family: "Newsreader", serif;
   font-style: italic;
-  font-size: 1rem;
-  max-width: 45ch;
-  line-height: 1.6;
-  color: var(--dark-text);
+  color: var(--muted-text);
 }
 
-.frame-bottom-text {
-  margin-top: 1rem;
+.pass-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  margin-top: 12px;
 }
 
-.festival-button {
-  display: inline-block;
-  background-color: var(--dusty-blue);
-  color: var(--light-beige);
-  font-family: 'Montserrat', sans-serif;
-  font-weight: 700;
-  text-decoration: none;
-  padding: 0.8rem 1.8rem;
-  border-radius: 50px;
-  margin-top: 1.5rem;
-  transition: transform 0.3s ease, box-shadow 0.3s ease, background-color 0.3s ease;
-  box-shadow: 0 5px 15px rgba(0,0,0,0.15);
+.plate.action-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 0.75rem 1.6rem;
+  font-weight: 600;
+  font-family: "Inter", sans-serif;
+  background: rgba(255, 255, 255, 0.7);
+  min-width: 0;
 }
 
-.festival-button:hover {
-  background-color: #7c8f99; /* Darker dusty blue */
-  transform: translateY(-3px);
-  box-shadow: 0 8px 20px rgba(0,0,0,0.2);
+.plate.action-button.primary {
+  border-color: rgba(0, 115, 198, 0.4);
+  color: var(--ink);
+  background: linear-gradient(135deg, rgba(0, 115, 198, 0.18), rgba(255, 255, 255, 0.78));
 }
 
-/* --- Subtle Background Elements --- */
-.bg-element {
+.plate.action-button.primary:hover {
+  transform: translateY(-2px);
+}
+
+.plate.action-button.secondary {
+  color: rgba(17, 17, 17, 0.55);
+  border-style: dashed;
+}
+
+.plate.action-button[aria-disabled="true"] {
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+.confetti-host {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  overflow: hidden;
+  z-index: 5;
+}
+
+.confetti-piece {
   position: absolute;
-  z-index: 1; /* Just above the background, below content */
-  width: var(--size);
-  height: var(--size);
-  background-image: var(--svg);
-  background-size: contain;
-  background-repeat: no-repeat;
+  top: -12vh;
+  width: var(--size, 10px);
+  height: calc(var(--size, 10px) * 0.6);
+  background: var(--color, var(--acc-gold));
+  border-radius: var(--radius-shape, 4px);
   opacity: 0;
-  animation: subtle-appear var(--duration) var(--delay) infinite ease-in-out;
-  will-change: opacity, transform;
+  transform: translate3d(0, 0, 0) rotate(0deg);
+  animation: confettiFall var(--duration, 2.6s) ease-in var(--delay, 0s) forwards;
 }
 
-@keyframes subtle-appear {
-  0%, 100% {
+@keyframes confettiFall {
+  0% {
+    transform: translate3d(0, -8vh, 0) rotateX(0deg) rotateY(0deg) rotateZ(0deg);
     opacity: 0;
-    transform: translateY(0) scale(1) rotate(var(--r-start));
   }
-  50% {
-    opacity: 0.08;
-    transform: translateY(-15px) scale(1.05) rotate(var(--r-end));
+  10% {
+    opacity: 1;
+  }
+  100% {
+    transform: translate3d(var(--drift, 0px), 70vh, 0) rotateZ(var(--rotation, 360deg));
+    opacity: 0;
+  }
+}
+
+body.gift-open .confetti-piece {
+  opacity: 1;
+}
+
+@media (max-width: 640px) {
+  .container {
+    padding-left: calc(18px + env(safe-area-inset-left, 0));
+    padding-right: calc(18px + env(safe-area-inset-right, 0));
+  }
+
+  .gift-box {
+    width: min(320px, 82vw);
+  }
+
+  .pass-header {
+    flex-direction: column;
+    text-align: center;
+  }
+
+  .pass-meta {
+    grid-template-columns: 1fr;
+  }
+
+  .pass-actions {
+    justify-content: center;
+  }
+}
+
+@media (max-width: 480px) {
+  .gift-hint {
+    font-size: 0.85rem;
+  }
+
+  .plate.action-button {
+    width: 100%;
   }
 }


### PR DESCRIPTION
## Summary
- restyled `gave.html` to mirror the Athina front page typography, palette and layout while introducing the festival-pass narrative flow
- rewrote `style.css` with shared CSS variables, animated envelope gift box, responsive festival pass layout and optional confetti styling that honours reduced-motion preferences
- replaced the JavaScript with an accessible open-gift controller that toggles states, launches confetti, and focuses the revealed content for keyboard and screen-reader users
- hid every Slottsfjell detail until after the gift opens and refreshed the playlist card that links to the surprise page

## Testing
- no automated tests were run (static HTML/CSS/JS page)

------
https://chatgpt.com/codex/tasks/task_e_68c9acf851888331ad9edf694293efe9