### PR TITLE
Update festival pass reveal for premium pass

### DIFF
--- a/gave.html
+++ b/gave.html
@@ -47,33 +47,10 @@
           <header class="pass-header">
             <img src="assets/slottsfjell-logo.png" alt="Logoen til Slottsfjell-festivalen" class="festival-logo" />
             <div class="pass-heading">
-              <p class="pass-label">Festivalpass</p>
+              <p class="pass-label">Festivalpass + Premium</p>
               <h2 id="festivalTitle" tabindex="-1">Slottsfjell 2026</h2>
             </div>
           </header>
-
-          <dl class="pass-meta">
-            <div>
-              <dt>Dato</dt>
-              <dd>9.–10. juli 2026</dd>
-            </div>
-            <div>
-              <dt>Sted</dt>
-              <dd>Slottsfjelltårnet, Tønsberg</dd>
-            </div>
-          </dl>
-
-          <p class="pass-intro">Gaven er billetter til Slottsfjell-festivalen 2026. Vi skal danse mellom tårnet og fjorden, midt i sommernatten.</p>
-          <p class="pass-note">Ta vare på dette digitale passet til vi står på sletten sammen. Jeg gleder meg til å oppleve alt dette med deg.</p>
-
-          <div class="pass-actions">
-            <a class="plate action-button primary" href="https://slottsfjell.no" target="_blank" rel="noopener" aria-label="Åpne nettsiden til Slottsfjell i en ny fane">
-              Utforsk slottsfjell.no
-            </a>
-            <button type="button" class="plate action-button secondary" aria-disabled="true">
-              Last ned billetten (kommer snart)
-            </button>
-          </div>
         </article>
       </section>
     </main>


### PR DESCRIPTION
## Summary
- update the revealed festival pass to show "Festivalpass + Premium" alongside the Slottsfjell 2026 heading
- remove the date, location, descriptive copy, and action buttons to match the simplified layout

## Testing
- No tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68c9c52182688331abfefab35793eef4